### PR TITLE
chore: update swc_core version from 14 to 18

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,9 +76,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "base64"
-version = "0.21.7"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64-simd"
@@ -504,20 +504,6 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hstr"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4032fdbefb72a4538180ef5dec6d0970e642f30f2e639c4d27e477afb5d97036"
-dependencies = [
- "hashbrown 0.14.5",
- "new_debug_unreachable",
- "once_cell",
- "phf",
- "rustc-hash 2.1.1",
- "triomphe",
-]
-
-[[package]]
-name = "hstr"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71399f53a92ef72ee336a4b30201c6e944827e14e0af23204c291aad9c24cc85"
@@ -868,9 +854,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "outref"
@@ -889,6 +875,25 @@ name = "owo-colors"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caff54706df99d2a78a5a4e3455ff45448d81ef1bb63c22cd14052ca0e993a3f"
+
+[[package]]
+name = "par-core"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b506ab63a8bd3cd38858c7bfc2d078a189dc3210c7f8c9be1bbaf50c082a0ae"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "par-iter"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a5b20f31e9ba82bfcbbb54a67aa40be6cebec9f668ba5753be138f9523c531a"
+dependencies = [
+ "either",
+ "par-core",
+]
 
 [[package]]
 name = "parking_lot"
@@ -1429,20 +1434,7 @@ dependencies = [
  "serde",
  "serde_json",
  "swc_core",
- "testing 8.0.0",
-]
-
-[[package]]
-name = "swc_allocator"
-version = "3.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d63ac41acf5c6d64fd1a8eccd4e53f30f45b6cfe86e8a4bcb40385068bbb1294"
-dependencies = [
- "bumpalo",
- "hashbrown 0.14.5",
- "ptr_meta",
- "rustc-hash 2.1.1",
- "triomphe",
+ "testing",
 ]
 
 [[package]]
@@ -1453,24 +1445,10 @@ checksum = "cc6b926f0d94bbb34031fe5449428cfa1268cdc0b31158d6ad9c97e0fc1e79dd"
 dependencies = [
  "allocator-api2",
  "bumpalo",
+ "hashbrown 0.14.5",
  "ptr_meta",
  "rustc-hash 2.1.1",
  "triomphe",
-]
-
-[[package]]
-name = "swc_atoms"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26769479f9cb4248b9c4a9ebde709e2657bb38d612576786680a2eed35c22549"
-dependencies = [
- "bytecheck",
- "hstr 0.3.1",
- "once_cell",
- "rancor",
- "rkyv",
- "rustc-hash 2.1.1",
- "serde",
 ]
 
 [[package]]
@@ -1479,17 +1457,20 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d7077ba879f95406459bc0c81f3141c529b34580bc64d7ab7bd15e7118a0391"
 dependencies = [
- "hstr 1.0.0",
+ "bytecheck",
+ "hstr",
  "once_cell",
+ "rancor",
+ "rkyv",
  "rustc-hash 2.1.1",
  "serde",
 ]
 
 [[package]]
 name = "swc_common"
-version = "7.0.0"
+version = "8.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601632c554875758657246e4971735d82ab59cfe13dcf496f70e5d9270f4c6f4"
+checksum = "9e4a932c152e7142de2d5dba1c393e5523c47cd8fe656e5b0d411954bbaf1810"
 dependencies = [
  "anyhow",
  "ast_node",
@@ -1508,36 +1489,8 @@ dependencies = [
  "serde",
  "siphasher",
  "sourcemap",
- "swc_allocator 3.0.1",
- "swc_atoms 4.0.0",
- "swc_eq_ignore_macros",
- "swc_visit",
- "termcolor",
- "tracing",
- "unicode-width",
- "url",
-]
-
-[[package]]
-name = "swc_common"
-version = "8.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26fbd21a1179166b5635d4b7a6b5930cf34b803a7361e0297b04f84dc820db04"
-dependencies = [
- "ast_node",
- "better_scoped_tls",
- "cfg-if",
- "either",
- "from_variant",
- "new_debug_unreachable",
- "num-bigint",
- "once_cell",
- "parking_lot",
- "rustc-hash 2.1.1",
- "serde",
- "siphasher",
- "swc_allocator 4.0.0",
- "swc_atoms 5.0.0",
+ "swc_allocator",
+ "swc_atoms",
  "swc_eq_ignore_macros",
  "swc_visit",
  "termcolor",
@@ -1548,14 +1501,14 @@ dependencies = [
 
 [[package]]
 name = "swc_core"
-version = "14.1.0"
+version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3be889540f3495d5ee9d34b2d23ff1d44a1fd000f84fb917bfb47f0a1ed4d78"
+checksum = "6448a3f005d6cd35ae201595669421af9292397e29d04530fa753069c9cf3913"
 dependencies = [
  "once_cell",
- "swc_allocator 3.0.1",
- "swc_atoms 4.0.0",
- "swc_common 7.0.0",
+ "swc_allocator",
+ "swc_atoms",
+ "swc_common",
  "swc_ecma_ast",
  "swc_ecma_parser",
  "swc_ecma_transforms_base",
@@ -1565,14 +1518,15 @@ dependencies = [
  "swc_plugin",
  "swc_plugin_macro",
  "swc_plugin_proxy",
+ "swc_transform_common",
  "vergen",
 ]
 
 [[package]]
 name = "swc_ecma_ast"
-version = "7.0.0"
+version = "8.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d856e3b85126e83d806b8d327ff6dc3708a4f512137510a210b8b0aaa2b1588b"
+checksum = "01f80679b1afc52ae0663eed0a2539cc3c108d48c287b5601712f9850d9fa9c2"
 dependencies = [
  "bitflags 2.5.0",
  "bytecheck",
@@ -1583,17 +1537,17 @@ dependencies = [
  "rkyv",
  "scoped-tls",
  "string_enum",
- "swc_atoms 4.0.0",
- "swc_common 7.0.0",
+ "swc_atoms",
+ "swc_common",
  "swc_visit",
  "unicode-id-start",
 ]
 
 [[package]]
 name = "swc_ecma_codegen"
-version = "7.0.0"
+version = "8.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a16d8fe0b81c3856cbd82c6bb7d28c21bd3891a387c9f1f862f545ce9b8a6e88"
+checksum = "f131ade75f9a3cfea38dbce11893f5636b0954de973ad29a2556124322a08372"
 dependencies = [
  "ascii",
  "compact_str",
@@ -1604,9 +1558,9 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "sourcemap",
- "swc_allocator 3.0.1",
- "swc_atoms 4.0.0",
- "swc_common 7.0.0",
+ "swc_allocator",
+ "swc_atoms",
+ "swc_common",
  "swc_ecma_ast",
  "swc_ecma_codegen_macros",
  "tracing",
@@ -1626,9 +1580,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_parser"
-version = "9.0.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ee398e6093d6816e060d44013f1b8111e2043367899bc05d01cac3fdce12301"
+checksum = "41e06ecaef86a547831f7f01f342434e4b0d0f363762f8e7a2b84da7a0a5f92e"
 dependencies = [
  "either",
  "new_debug_unreachable",
@@ -1640,8 +1594,8 @@ dependencies = [
  "smallvec",
  "smartstring",
  "stacker",
- "swc_atoms 4.0.0",
- "swc_common 7.0.0",
+ "swc_atoms",
+ "swc_common",
  "swc_ecma_ast",
  "tracing",
  "typed-arena",
@@ -1649,46 +1603,46 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_testing"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8337a466d19da1d3bfcb6f8b12113fb8c82cf6664602b1183ef46ca9d7a8c66e"
+checksum = "5e72a43b7acd904fa0c6d244a72aeda66febbc5a9720975481cb836d6804b604"
 dependencies = [
  "anyhow",
  "hex",
  "sha2",
- "testing 7.0.0",
+ "testing",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_base"
-version = "10.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f73624c31126342dd5b53938a1a4a405ce73ce60b2498af86b432793e58b9e7"
+checksum = "b0b747f04a004d9b56b903305e4567e1d30c9cd226a8310a29cac06f7ac8173a"
 dependencies = [
  "better_scoped_tls",
  "bitflags 2.5.0",
  "indexmap",
  "once_cell",
+ "par-core",
  "phf",
  "rustc-hash 2.1.1",
  "serde",
  "smallvec",
- "swc_atoms 4.0.0",
- "swc_common 7.0.0",
+ "swc_atoms",
+ "swc_common",
  "swc_ecma_ast",
  "swc_ecma_parser",
  "swc_ecma_utils",
  "swc_ecma_visit",
- "swc_parallel",
  "tracing",
 ]
 
 [[package]]
 name = "swc_ecma_transforms_testing"
-version = "10.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfbda9a6efd41c8fe47f0800913bb5c092313d2bdeb9ede8d6006701e4b3d1cb"
+checksum = "c9e812e5d5c89ac4559a2bb8bc7dcff2d09de7f7d4fc77a53293b93cb1bf9554"
 dependencies = [
  "ansi_term",
  "anyhow",
@@ -1698,8 +1652,8 @@ dependencies = [
  "serde_json",
  "sha2",
  "sourcemap",
- "swc_allocator 3.0.1",
- "swc_common 7.0.0",
+ "swc_allocator",
+ "swc_common",
  "swc_ecma_ast",
  "swc_ecma_codegen",
  "swc_ecma_parser",
@@ -1708,39 +1662,40 @@ dependencies = [
  "swc_ecma_utils",
  "swc_ecma_visit",
  "tempfile",
- "testing 7.0.0",
+ "testing",
 ]
 
 [[package]]
 name = "swc_ecma_utils"
-version = "10.0.0"
+version = "12.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12f3f5232b8fb1c756d428a36f09df1dac2f44d77951d7f946cab809757deab6"
+checksum = "71d6c8ba7d987dcc254f05ad2c23e7a6ec3f259611af2923a8c1a0602556cd21"
 dependencies = [
  "indexmap",
  "num_cpus",
  "once_cell",
+ "par-core",
+ "par-iter",
  "rustc-hash 2.1.1",
  "ryu-js",
- "swc_atoms 4.0.0",
- "swc_common 7.0.0",
+ "swc_atoms",
+ "swc_common",
  "swc_ecma_ast",
  "swc_ecma_visit",
- "swc_parallel",
  "tracing",
  "unicode-id",
 ]
 
 [[package]]
 name = "swc_ecma_visit"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "195a418699326c6a4be906ecd3144d58335bef9c166f07ecfa1b7399028733aa"
+checksum = "2f7a65fa06d0c0f709f1df4e820ccdc4eca7b3db7f9d131545e20c2ac2f1cd23"
 dependencies = [
  "new_debug_unreachable",
  "num-bigint",
- "swc_atoms 4.0.0",
- "swc_common 7.0.0",
+ "swc_atoms",
+ "swc_common",
  "swc_ecma_ast",
  "swc_visit",
  "tracing",
@@ -1759,19 +1714,6 @@ dependencies = [
 
 [[package]]
 name = "swc_error_reporters"
-version = "8.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d89a68d5725643421457eb8cde1f6d05c4d704bbb884044c889fb7e729effd"
-dependencies = [
- "anyhow",
- "miette",
- "once_cell",
- "parking_lot",
- "swc_common 7.0.0",
-]
-
-[[package]]
-name = "swc_error_reporters"
 version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10ad5f4690758cedc202cf0f4c9d2369372c6692307f65bd40031de494662cfa"
@@ -1780,7 +1722,7 @@ dependencies = [
  "miette",
  "once_cell",
  "parking_lot",
- "swc_common 8.0.0",
+ "swc_common",
 ]
 
 [[package]]
@@ -1792,15 +1734,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "swc_parallel"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5f75f1094d69174ef628e3665fff0f81d58e9f568802e3c90d332c72b0b6026"
-dependencies = [
- "once_cell",
 ]
 
 [[package]]
@@ -1825,16 +1758,16 @@ dependencies = [
 
 [[package]]
 name = "swc_plugin_proxy"
-version = "7.0.0"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac6c5059fba4db71d99d1df451f57ddc8c01a150c04662075ac1b20acd1c858"
+checksum = "a18c199683d9f946db8dfca444212a3551e74a7c563196b154d5ac30f3bf9de6"
 dependencies = [
  "better_scoped_tls",
  "bytecheck",
  "rancor",
  "rkyv",
  "rustc-hash 2.1.1",
- "swc_common 7.0.0",
+ "swc_common",
  "swc_ecma_ast",
  "swc_trace_macro",
  "tracing",
@@ -1849,6 +1782,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "swc_transform_common"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40bbeef964d6edd66081a31bbfeef913bb0be536e398392f99e8e91b7da63eb"
+dependencies = [
+ "better_scoped_tls",
+ "once_cell",
+ "rustc-hash 2.1.1",
+ "serde",
+ "serde_json",
+ "swc_common",
 ]
 
 [[package]]
@@ -1913,28 +1860,6 @@ dependencies = [
 
 [[package]]
 name = "testing"
-version = "7.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357b1e3ef6414c8a97e0d4701a67ee52ea65095f7afb7fcc8a3609efdc0e7cf4"
-dependencies = [
- "ansi_term",
- "cargo_metadata 0.18.1",
- "difference",
- "once_cell",
- "pretty_assertions",
- "regex",
- "rustc-hash 2.1.1",
- "serde",
- "serde_json",
- "swc_common 7.0.0",
- "swc_error_reporters 8.0.0",
- "testing_macros",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
-name = "testing"
 version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d32ddc0e2ebd072cbffe7424087267da990708a5bc3ae29e075904468450275"
@@ -1948,8 +1873,8 @@ dependencies = [
  "rustc-hash 2.1.1",
  "serde",
  "serde_json",
- "swc_common 8.0.0",
- "swc_error_reporters 9.0.0",
+ "swc_common",
+ "swc_error_reporters",
  "testing_macros",
  "tracing",
  "tracing-subscriber",

--- a/plugin/Cargo.toml
+++ b/plugin/Cargo.toml
@@ -13,5 +13,5 @@ crate-type = ["cdylib"]
 
 [dependencies]
 serde_json = "1.0"
-swc_core = { version = "14.0", features = ["ecma_plugin_transform"] }
+swc_core = { version = "18.0", features = ["ecma_plugin_transform"] }
 swc-vue-jsx-visitor = { path = "../visitor", version = "*" }

--- a/visitor/Cargo.toml
+++ b/visitor/Cargo.toml
@@ -14,7 +14,7 @@ fnv = "1.0"
 indexmap = "2.1"
 regex = "1.10"
 serde = { version = "1.0", features = ["derive"] }
-swc_core = { version = "14.0", features = [
+swc_core = { version = "18.0", features = [
   "ecma_parser",
   "ecma_plugin_transform",
   "ecma_utils",

--- a/visitor/src/directive.rs
+++ b/visitor/src/directive.rs
@@ -3,7 +3,7 @@ use swc_core::{
     common::DUMMY_SP,
     ecma::{
         ast::*,
-        atoms::JsWord,
+        atoms::Atom,
         utils::{quote_ident, quote_str},
     },
     plugin::errors::HANDLER,
@@ -18,7 +18,7 @@ pub(crate) fn is_directive(jsx_attr: &JSXAttr) -> bool {
 }
 
 pub(crate) struct NormalDirective {
-    pub(crate) name: JsWord,
+    pub(crate) name: Atom,
     pub(crate) argument: Option<Expr>,
     pub(crate) modifiers: Option<Expr>,
     pub(crate) value: Expr,
@@ -106,19 +106,19 @@ pub(crate) fn parse_directive(jsx_attr: &JSXAttr, is_component: bool) -> Directi
                     }
                 }
             } else {
-                modifiers = Some(splitted.map(JsWord::from).collect());
+                modifiers = Some(splitted.map(Atom::from).collect());
             }
         } else {
-            modifiers = Some(splitted.map(JsWord::from).collect());
+            modifiers = Some(splitted.map(Atom::from).collect());
             value = (**expr).clone();
         }
     } else {
-        modifiers = Some(splitted.map(JsWord::from).collect());
+        modifiers = Some(splitted.map(Atom::from).collect());
         value = Expr::Ident(quote_ident!("").into());
     }
 
     Directive::Normal(NormalDirective {
-        name: JsWord::from(name),
+        name: Atom::from(name),
         argument: if modifiers
             .as_ref()
             .map(|modifiers| !modifiers.is_empty())
@@ -143,7 +143,7 @@ pub(crate) fn parse_directive(jsx_attr: &JSXAttr, is_component: bool) -> Directi
     })
 }
 
-fn parse_modifiers(exprs: &[Option<ExprOrSpread>]) -> BTreeSet<JsWord> {
+fn parse_modifiers(exprs: &[Option<ExprOrSpread>]) -> BTreeSet<Atom> {
     exprs
         .iter()
         .filter_map(|expr| match expr {
@@ -275,10 +275,10 @@ fn parse_v_model_directive(
             if is_component && argument.is_none() {
                 argument = Some(Expr::Lit(Lit::Null(Null { span: DUMMY_SP })));
             }
-            modifiers = Some(splitted_attr_name.map(JsWord::from).collect());
+            modifiers = Some(splitted_attr_name.map(Atom::from).collect());
         }
     } else {
-        modifiers = Some(splitted_attr_name.map(JsWord::from).collect());
+        modifiers = Some(splitted_attr_name.map(Atom::from).collect());
         value = attr_value.clone();
     }
 
@@ -309,7 +309,7 @@ fn parse_v_model_directive(
     })
 }
 
-fn transform_modifiers(modifiers: BTreeSet<JsWord>, quote_prop: bool) -> Option<Expr> {
+fn transform_modifiers(modifiers: BTreeSet<Atom>, quote_prop: bool) -> Option<Expr> {
     if modifiers.is_empty() {
         None
     } else {

--- a/visitor/src/lib.rs
+++ b/visitor/src/lib.rs
@@ -9,7 +9,7 @@ use swc_core::{
     common::{comments::Comments, Mark, Span, Spanned, SyntaxContext, DUMMY_SP},
     ecma::{
         ast::*,
-        atoms::JsWord,
+        atoms::Atom,
         utils::{private_ident, quote_ident, quote_str},
         visit::{VisitMut, VisitMutWith},
     },
@@ -42,8 +42,8 @@ where
     transform_on_helper: Option<Ident>,
 
     define_component: Option<SyntaxContext>,
-    interfaces: FnvHashMap<(JsWord, SyntaxContext), TsInterfaceDecl>,
-    type_aliases: FnvHashMap<(JsWord, SyntaxContext), TsType>,
+    interfaces: FnvHashMap<(Atom, SyntaxContext), TsInterfaceDecl>,
+    type_aliases: FnvHashMap<(Atom, SyntaxContext), TsType>,
 
     unresolved_mark: Mark,
     comments: Option<C>,
@@ -410,7 +410,7 @@ where
                                     }
                                 } else {
                                     directives.push(NormalDirective {
-                                        name: JsWord::from("model"),
+                                        name: Atom::from("model"),
                                         argument: directive.transformed_argument,
                                         modifiers: directive.modifiers.clone(),
                                         value: directive.value.clone(),


### PR DESCRIPTION
changelog:
1. replace macro `js_word` to `atom` and replace `JsWord` to `Atom`: [refactor(atoms): Remove JsWord alias](https://github.com/swc-project/swc/pull/10071/commits/3042a66d700daf1e5d06f629d7ff1872c2dd9c5d)